### PR TITLE
Added two more RC plates to OreDict unification.

### DIFF
--- a/src/main/java/gregtechmod/loaders/preload/GT_DictRegistratorPostItem.java
+++ b/src/main/java/gregtechmod/loaders/preload/GT_DictRegistratorPostItem.java
@@ -19,6 +19,8 @@ public class GT_DictRegistratorPostItem implements Runnable {
 		GT_Log.log.info("Registering other Stuff to the OreDict.");
 		GT_OreDictUnificator.set(OrePrefixes.plate, Materials.Iron					, GT_ModHandler.getRCItem("part.plate.iron", 1L));
 		GT_OreDictUnificator.set(OrePrefixes.plate, Materials.Steel					, GT_ModHandler.getRCItem("part.plate.steel", 1L));
+		GT_OreDictUnificator.set(OrePrefixes.plate, Materials.Copper				, GT_ModHandler.getRCItem("part.plate.copper", 1L));
+		GT_OreDictUnificator.set(OrePrefixes.plate, Materials.Lead					, GT_ModHandler.getRCItem("part.plate.lead", 1L));
 		
 	    GT_OreDictUnificator.set(OrePrefixes.circuit, Materials.Basic				, GT_ModHandler.getIC2Item("electronicCircuit", 1L));
 	    GT_OreDictUnificator.set(OrePrefixes.circuit, Materials.Advanced			, GT_ModHandler.getIC2Item("advancedCircuit", 1L));


### PR DESCRIPTION
Copper and Lead plates were added in 1.7 versions of Railcraft so they never received an official integration in GT4.

![2021-09-28_02 48 05](https://user-images.githubusercontent.com/5104603/135000434-b7ce3a9e-f1af-4111-a509-25ea7efb0c85.png)
![2021-09-28_02 48 15](https://user-images.githubusercontent.com/5104603/135000437-59ecd708-56b2-492f-bb34-ee965e0eb0b2.png)

