### PR TITLE
Fix GT axes using proper MCP name for break speed function override.

### DIFF
--- a/src/main/java/gregtechmod/common/items/GT_Vanilla_Axe.java
+++ b/src/main/java/gregtechmod/common/items/GT_Vanilla_Axe.java
@@ -12,7 +12,8 @@ public class GT_Vanilla_Axe extends GT_Vanilla_Tool {
 		setHarvestLevel("axe", mHarvestLevel);
 	}
 	
-    public float getStrVsBlock(ItemStack aStack, Block aBlock) {
+    @Override
+    public float func_150893_a(ItemStack aStack, Block aBlock) {
         return aBlock != null && (aBlock.getMaterial() == Material.wood || aBlock.getMaterial() == Material.plants || aBlock.getMaterial() == Material.vine) ? this.efficiencyOnProperMaterial : super.func_150893_a(aStack, aBlock);
     }
 }


### PR DESCRIPTION
Fix for #171.