### PR TITLE
Expanded OreDict Handler Blacklist

### DIFF
--- a/src/main/java/gregtechmod/common/GT_OreDictHandler.java
+++ b/src/main/java/gregtechmod/common/GT_OreDictHandler.java
@@ -40,7 +40,7 @@ public class GT_OreDictHandler {
 	
 	private final Map<OrePrefixes, List<OreDictEntry>> mEvents = new HashMap<>();
 	private final List<String> mIgnoredItems = Arrays.asList(new String[]{"itemRawRubber", "itemSilicon", "itemBacon", "itemJetpackAccelerator", "itemLazurite", "itemIridium", "itemTear", "itemClaw", "itemFertilizer", "itemTar", "itemSlimeball", "itemCoke", "itemBeeswax", "itemBeeQueen", "itemForcicium", "itemForcillium", "itemRoyalJelly", "itemHoneydew", "itemHoney", "itemPollen", "itemReedTypha", "itemSulfuricAcid", "itemPotash", "itemCompressedCarbon", "itemBitumen", "itemBioFuel", "itemCokeSugar", "itemCokeCactus", "itemCharcoalSugar", "itemCharcoalCactus", "itemSludge", "itemEnrichedAlloy", "itemQuicksilver", "itemMercury", "itemOsmium", "itemUltimateCircuit", "itemEnergizedStar", "itemAntimatterMolecule", "itemAntimatterGlob", "itemCoal", "itemBoat", "itemHerbalMedicineCake", "itemCakeSponge", "itemFishandPumpkinCakeSponge", "itemSoulCleaver", "itemInstantCake", "itemWhippingCream", "itemGlisteningWhippingCream", "itemCleaver", "itemHerbalMedicineWhippingCream", "itemStrangeWhippingCream", "itemBlazeCleaver", "itemBakedCakeSponge", "itemMagmaCake", "itemGlisteningCake", "itemOgreCleaver", "itemFishandPumpkinCake", "itemMagmaWhippingCream", "itemMultimeter", "itemSuperconductor"});
-	private final List<String> mIgnoredNames = Arrays.asList(new String[]{"whiteStone", "stoneSlab", "clayBowl", "clayPlate", "ceramicBowl", "ceramicPlate", "ovenRack", "clayCup", "ceramicCup", "batteryBox", "transmutationStone", "torchRedstoneActive", "coal", "charcoal", "cloth", "cobblestoneSlab", "stoneBrickSlab", "cobblestoneWall", "stoneBrickWall", "cobblestoneStair", "stoneBrickStair", "blockCloud", "blockDirt", "blockTyrian", "blockCarpet", "blockFft", "blockLavastone", "blockHolystone", "blockConcrete", "sunnariumPart", "brSmallMachineCyaniteProcessor", "meteoriteCoal", "blockCobble", "pressOreProcessor", "crusherOreProcessor", "grinderOreProcessor", "blockRubber", "blockHoney", "blockHoneydew", "blockPeat", "blockRadioactive", "blockSlime", "blockCocoa", "blockSugarCane", "blockLeather", "blockClayBrick", "solarPanelHV", "cableRedNet", "stoneBowl", "crafterWood", "taintedSoil", "brickXyEngineering", "breederUranium", "wireMill", "chunkLazurite", "aluminumNatural", "aluminiumNatural", "naturalAluminum", "naturalAluminium", "antimatterMilligram", "antimatterGram", "strangeMatter", "coalGenerator", "electricFurnace", "unfinishedTank", "valvePart", "aquaRegia", "leatherSeal", "leatherSlimeSeal", "hambone", "slimeball", "enrichedUranium", "camoPaste"});
+	private final List<String> mIgnoredNames = Arrays.asList(new String[]{"whiteStone", "stoneSlab", "clayBowl", "clayPlate", "ceramicBowl", "ceramicPlate", "ovenRack", "clayCup", "ceramicCup", "batteryBox", "transmutationStone", "torchRedstoneActive", "coal", "charcoal", "cloth", "cobblestoneSlab", "stoneBrickSlab", "cobblestoneWall", "stoneBrickWall", "cobblestoneStair", "stoneBrickStair", "blockCloud", "blockDirt", "blockTyrian", "blockCarpet", "blockFft", "blockLavastone", "blockHolystone", "blockConcrete", "sunnariumPart", "brSmallMachineCyaniteProcessor", "meteoriteCoal", "blockCobble", "pressOreProcessor", "crusherOreProcessor", "grinderOreProcessor", "blockRubber", "blockHoney", "blockHoneydew", "blockPeat", "blockRadioactive", "blockSlime", "blockCocoa", "blockSugarCane", "blockLeather", "blockClayBrick", "solarPanelHV", "cableRedNet", "stoneBowl", "crafterWood", "taintedSoil", "brickXyEngineering", "breederUranium", "wireMill", "chunkLazurite", "aluminumNatural", "aluminiumNatural", "naturalAluminum", "naturalAluminium", "antimatterMilligram", "antimatterGram", "strangeMatter", "coalGenerator", "electricFurnace", "unfinishedTank", "valvePart", "aquaRegia", "leatherSeal", "leatherSlimeSeal", "hambone", "slimeball", "enrichedUranium", "camoPaste", "livingrock", "quicksilver", "nuggetQuicksilver", "dirt", "grass", "gravel", "mycelium", "podzol", "netherrack", "ice", "chest"});
 	private final List<String> mInvalidNames = Arrays.asList(new String[]{"bloodstoneOre", "universalCable", "bronzeTube", "ironTube", "netherTube", "obbyTube", "infiniteBattery", "eliteBattery", "advancedBattery", "10kEUStore", "blueDye", "MonazitOre", "quartzCrystal", "whiteLuminiteCrystal", "darkStoneIngot", "invisiumIngot", "demoniteOrb", "enderGem", "starconiumGem", "osmoniumIngot", "tapaziteGem", "zectiumIngot", "foolsRubyGem", "rubyGem", "meteoriteGem", "adamiteShard", "sapphireGem", "copperIngot", "ironStick", "goldStick", "diamondStick", "reinforcedStick", "draconicStick", "emeraldStick", "copperStick", "tinStick", "silverStick", "bronzeStick", "steelStick", "leadStick", "manyullynStick", "arditeStick", "cobaltStick", "aluminiumStick", "alumiteStick", "oilsandsOre", "copperWire", "superconductorWire", "sulfuricAcid", "conveyorBelt", "ironWire", "aluminumWire", "aluminiumWire", "silverWire", "tinWire", "dustSiliconSmall", "AluminumOre", "plateHeavyT2", "blockWool", "alloyPlateEnergizedHardened", "gasWood", "alloyPlateEnergized", "SilverOre", "LeadOre", "TinOre", "CopperOre", "silverOre", "leadOre", "tinOre", "copperOre", "bauxiteOre", "HSLivingmetalIngot", "oilMoving", "oilStill", "oilBucket", "petroleumOre", "dieselFuel", "diamondNugget", "planks", "wood", "stick", "sticks", "naquadah", "obsidianRod", "stoneRod", "thaumiumRod", "steelRod", "netherrackRod", "woodRod", "ironRod", "cactusRod", "flintRod", "copperRod", "cobaltRod", "alumiteRod", "blueslimeRod", "arditeRod", "manyullynRod", "bronzeRod", "boneRod", "slimeRod"});
 	private final List<String> mIgnoredPrefixes = Arrays.asList(new String[]{"reactor", "mffs", "projred", "ganys"});
 	private boolean mActivated = false;
@@ -57,10 +57,41 @@ public class GT_OreDictHandler {
 			aEvent.Ore.stackSize = 1;
 			
 			ModContainer tContainer = Loader.instance().activeModContainer();
-			String aMod = tContainer == null ? "minecraft" : tContainer.getModId();
+			String aMod = tContainer == null ? "minecraft" : tContainer.getModId();         
 			
-			
-	    	if (aMod.toLowerCase().contains("tconstruct") || aMod.toLowerCase().contains("xycraft") || (aMod.toLowerCase().contains("natura") || aMod.toLowerCase().contains("natural"))) return;
+         ////TO DO: Make this into a config
+         List<String> Blacklist = new ArrayList<String>(); 
+         
+         Blacklist.add("TConstruct");
+         Blacklist.add("Xycraft");
+         Blacklist.add("Natura");
+         Blacklist.add("Natural");
+         Blacklist.add("BiblioCraft");
+         Blacklist.add("BiblioWoods");
+         Blacklist.add("Botania");
+         Blacklist.add("Botany");
+         Blacklist.add("ExtraTiC");
+         Blacklist.add("ExtraTrees");
+         Blacklist.add("ExtraUtilities");
+         Blacklist.add("ForbiddenMagic");
+         Blacklist.add("ForgeMicroblock");
+         Blacklist.add("ForgottenRelics");
+         Blacklist.add("HardcoreEnderExpansion");
+         Blacklist.add("NuclearCraft");
+         Blacklist.add("OpenBlocks");
+         Blacklist.add("OpenComputers");
+         Blacklist.add("RandomThings");
+         Blacklist.add("StorageDrawers");
+         Blacklist.add("ThaumicExploration");
+         Blacklist.add("WarpDrive");
+         Blacklist.add("chisel");
+         Blacklist.add("rftools");
+         Blacklist.add("thaumcraftneiplugin");
+         Blacklist.add("thaumicdyes");        
+         Blacklist.add("ProjRed|Illumination");
+         //
+
+	    	if (Blacklist.contains(aMod)) return;
 			if (mActivated || GregTech_API.sPostloadStarted || GT_Mod.sSortToTheEnd && GregTech_API.sLoadFinished) {
 				GT_Log.log.warn("WARNING: " + aMod + " attempted to register " + aEvent.Name + " very late at the OreDictionary! Some Functionality may not work as expected! Sometimes registration in Postload is required, but you should always register OreDictionary Items in the Load Phase whenever possible.");
 			}


### PR DESCRIPTION
Improves GT4 loading times when paired with these mods without affecting gameplay since none of them have applicable oredict.

 **Before:**
```
[Client thread/DEBUG] [FML/gregtech_addon]: Bar Finished: Handling OreDict took 36.988s
 [Client thread/WARN] [GregTech/gregtech_addon]: Time spent for oredict iterating: 36.988 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Activating Recipe handler
 [Client thread/INFO] [GregTech/gregtech_addon]: 	Smelting processor finished for 0.014 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	Crafting processor finished for 0.856 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	IC2 Recipe processor finished for 0.029 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	OnFinish tasks completed for 3.366 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Recipe handler finished for 4.267 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Congratulations, you have been waiting long enough. Have a Cake.
```

 **After:**
 ```
[Client thread/DEBUG] [FML/gregtech_addon]: Bar Finished: Handling OreDict took 0.721s
 [Client thread/WARN] [GregTech/gregtech_addon]: Time spent for oredict iterating: 0.721 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Activating Recipe handler
 [Client thread/INFO] [GregTech/gregtech_addon]: 	Smelting processor finished for 0.001 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	Crafting processor finished for 0.055 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	IC2 Recipe processor finished for 0.001 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: 	OnFinish tasks completed for 0.163 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Recipe handler finished for 0.220 seconds
 [Client thread/INFO] [GregTech/gregtech_addon]: Congratulations, you have been waiting long enough. Have a Cake.
```
Mostly due to item copies with just different textures like the different Bibliocraft tables made of a specific wood.